### PR TITLE
fix(config:build): corrige le chemin du fichier principal dans Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ USER appuser
 
 EXPOSE 3000
 
-CMD ["node", "dist/main"]
+CMD ["node", "dist/src/main"]


### PR DESCRIPTION
- Modifie la commande CMD pour pointer vers `dist/src/main` au lieu de `dist/main`.
- Corrige une erreur d'exécution causée par un chemin incorrect dans l'image Docker.