### PR TITLE
fix(config:env): change l'origine autorisée par défaut pour CORS

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ async function bootstrap() {
   app.useGlobalFilters(new AllExceptionsFilter());
 
   // Enable CORS for Angular frontend
-  let allowedOrigins = ['http://localhost:4200']; // Default fallback
+  let allowedOrigins = ['https://nedellec-julien.fr']; // Default fallback
   try {
     if (process.env.ALLOWED_ORIGINS) {
       allowedOrigins = JSON.parse(process.env.ALLOWED_ORIGINS) as string[];


### PR DESCRIPTION
- Remplace `http://localhost:4200` par `https://nedellec-julien.fr` comme origine autorisée par défaut.
- Assure la compatibilité avec le déploiement en production tout en conservant une gestion des origines via l'environnement.