### PR TITLE
fix(component:cv): corrige la création de CV avec le chemin du fichier

### DIFF
--- a/src/features/cv/cv.controller.ts
+++ b/src/features/cv/cv.controller.ts
@@ -62,7 +62,7 @@ export class CvController {
   @Post('upload-file')
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(FileInterceptor('file', getMulterConfig()))
-  uploadFile(
+  async uploadFile(
     @UploadedFile(
       new ParseFilePipe({
         validators: [new MaxFileSizeValidator({ maxSize: 5 * 1024 * 1024 })],
@@ -70,7 +70,14 @@ export class CvController {
     )
     file: Express.Multer.File,
   ) {
+    const createCvDto: CreateCvDto = {
+      filePath: file.path,
+    };
+
+    const cv = await this.cvService.create(createCvDto);
+
     return {
+      id: cv.id,
       filename: file.filename,
       path: file.path,
       mimetype: file.mimetype,

--- a/src/features/cv/dto/create-cv.dto.ts
+++ b/src/features/cv/dto/create-cv.dto.ts
@@ -1,23 +1,7 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateCvDto {
+  @IsString()
   @IsNotEmpty()
-  @IsString()
-  firstName: string;
-
-  @IsNotEmpty()
-  @IsString()
-  lastName: string;
-
-  @IsNotEmpty()
-  @IsString()
-  jobTitle: string;
-
-  @IsNotEmpty()
-  @IsString()
-  jobDescription: string;
-
-  @IsOptional()
-  @IsString()
-  filePath?: string;
+  filePath: string;
 }


### PR DESCRIPTION
- Remplace l'attribut `filePath` marqué comme optionnel par une exigence obligatoire dans `CreateCvDto`.
- Ajoute une création de CV à la réponse de l'upload pour inclure l'ID généré.