### PR TITLE
fix(component:cv): adapte l'en-tête Content-Disposition

### DIFF
--- a/src/features/cv/cv.controller.ts
+++ b/src/features/cv/cv.controller.ts
@@ -124,7 +124,7 @@ export class CvController {
     }
 
     res.setHeader('Content-Type', contentType);
-    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Content-Disposition', `inline; filename="${filename}"`);
 
     const fileStream = fs.createReadStream(cvWithFile.filePath);
     fileStream.pipe(res);


### PR DESCRIPTION
- Change l'en-tête `Content-Disposition` de `attachment` à `inline` afin de permettre la prévisualisation directe des CV dans le navigateur.
- Conserve la possibilité de téléchargement via un clic droit ou un menu contextuel.