### PR TITLE
fix(config:env): ajoute les en-têtes exposés et autorisés pour CORS

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,8 @@ async function bootstrap() {
     origin: allowedOrigins,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     credentials: true,
+    exposedHeaders: ['Content-Type', 'Authorization'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
   });
 
   app.useGlobalPipes(


### PR DESCRIPTION
- Ajoute les en-têtes `exposedHeaders` et `allowedHeaders` pour inclure `Content-Type` et `Authorization`.
- Améliore la gestion des requêtes inter-origines nécessitant ces en-têtes dans les configurations CORS.